### PR TITLE
Adiciona versao da matriz de comunicacao enviada a ASCOM

### DIFF
--- a/matriz-comunicacao.md
+++ b/matriz-comunicacao.md
@@ -1,0 +1,47 @@
+# Matriz de Comunicação - Blog Dados Abertos
+
+## Matriz de Canais
+
+### Linha Editorial
+
+Canal de compartilhamento do processo de internalização de Boas Práticas para Dados na Web para os processos envolvidos na manutenção do Portal da Transparência.
+
+__Objetivos:__
+
+* Sensibilizar sociedade e atores institucionais sobre a importância da transparência e a abertura de dados;
+* Tornar a CGE multiplicadora do movimento de abertura de dados de governo;
+* Engajar cidadãos.
+
+### Público-Alvo
+
+Servidores públicos (CGE, outros órgãos e outros entes e esferas de gestão), cidadãos.
+
+### Atributo Principal
+
+Transparência, integração, profundidade
+
+### Periodicidade de Atualização
+
+Quinzenal
+
+## Comunicação Externa
+
+### Ação
+
+* Postagens de conteúdos sobre a importância da adoção de melhores práticas na edição e publicação de dados de governo;
+* Condução de avaliações de qualidade dos dados publicados via modelos de maturidade de publicação de dados abertos (ação prevista no planejamento estratégico da CGE);
+* Planejamento da evolução das funcionalidades do Portal de Dados Abertos do Governo Estadual.       
+
+### Objetivos Imediatos
+
+* Aumentar os acessos aos Portais institucionais da CGE: Transparência e Dados Abertos;
+* Induzir a alfabetização de dados de servidores e comunidade interessada;
+* Induzir a criação de um ambiente de cocriação e colaboração entre diversos atores institucionais;
+* Amplificar o papel dos Portais de Transparência e Dados Abertos da CGE enquanto fontes de pesquisa da sociedade - servidores, controle externo, academia, imprensa;
+* Aumento da percepção de transparência do Estado.
+
+### Objetivos Estratégicos
+
+* Sensibilizar sociedade e atores institucionais sobre a importância da transparência e a abertura de dados
+* Tornar a CGE multiplicadora do movimento de abertura de dados de governo
+* Engajar cidadãos


### PR DESCRIPTION
Essa matriz de comunicação foi enviada para a ASCOM em 12/08 quando o Plano de Comunicação da CGE foi colocado em Consulta Aberta.

Ele precisa ser revisada com base no conteúdo da [apresentação executiva](https://github.com/transparencia-mg/blog-dados-abertos/blob/canvas/canvas.md) (canvas) e [fluxo editorial](https://github.com/transparencia-mg/blog-dados-abertos/blob/politica-editorial/politica-editorial.md).

* [Link](https://github.com/transparencia-mg/blog-dados-abertos/blob/matriz-comunicacao/matriz-comunicacao.md)